### PR TITLE
Explicitly create dependency on publish task

### DIFF
--- a/utils-kotlin/src/main/kotlin/com/eygraber/gradle/kotlin/kmp/spm/spm_maven.kt
+++ b/utils-kotlin/src/main/kotlin/com/eygraber/gradle/kotlin/kmp/spm/spm_maven.kt
@@ -33,6 +33,8 @@ public fun Project.registerPublishSpmToMavenTasks(
         "${CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, frameworkName)}-${project.name}"
 
       tasks.register("publish${frameworkName}ToMaven", PublishXCFrameworkTask::class.java) {
+        dependsOn(publishTask)
+
         publishedUrl.set(
           publishTask.map {
             "${it.repository.url}/${rootProject.name}/$artifactName/$artifactVersion/$artifactName-$artifactVersion.zip"

--- a/utils-kotlin/src/main/kotlin/com/eygraber/gradle/kotlin/kmp/spm/spm_publish.kt
+++ b/utils-kotlin/src/main/kotlin/com/eygraber/gradle/kotlin/kmp/spm/spm_publish.kt
@@ -112,6 +112,8 @@ internal fun Project.registerPublishReleaseSpm(
 
     onlyIf { HostManager.hostIsMac }
 
+    dependsOn(publishTask)
+
     val publishedUrl = publishTask.flatMap { it.publishedUrl }
     val zipFile = zipTask.flatMap { it.archiveFile }
 


### PR DESCRIPTION
  - I'm thinking that because it's not using outputs of the task, the wiring doesn't happen implicitly