### PR TITLE
Don't allow accessors to be used

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  no_accessors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+
+      - name: Don't allow any accessor imports
+        run: if grep --include=\*.{kt,kts} -rne 'import gradle\.kotlin\.dsl\.accessors\._' .; then false; else true; fi
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
  - Tedious to use them because the package sometimes updates when Gradle updates and not easy to find the new package