### PR TITLE
Remove custom web source sets

### DIFF
--- a/conventions-plugin/src/main/kotlin/com/eygraber/conventions/kotlin/GradleConventionsKmp.kt
+++ b/conventions-plugin/src/main/kotlin/com/eygraber/conventions/kotlin/GradleConventionsKmp.kt
@@ -9,7 +9,6 @@ import org.gradle.api.services.BuildServiceParameters
 import javax.inject.Inject
 
 interface GradleConventionsKmp {
-  var createCommonJsSourceSet: Boolean
   var webOptions: KmpTarget.WebOptions
 
   var binaryType: BinaryType
@@ -19,8 +18,6 @@ interface GradleConventionsKmp {
 }
 
 internal abstract class GradleConventionsKmpDefaults : BuildService<BuildServiceParameters.None>, GradleConventionsKmp {
-  override var createCommonJsSourceSet: Boolean = true
-
   override var binaryType: BinaryType = BinaryType.Library
   override var webOptions = KmpTarget.WebOptions()
 


### PR DESCRIPTION
  - Kotlin 2.2.20 is adding a web source set so we don't need to provide our own anymore